### PR TITLE
Run EMR in private subnet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+cdk.context.json
 build/
 node_modules/
 lerna-debug.log*

--- a/README.md
+++ b/README.md
@@ -19,16 +19,18 @@ npx moonset config
 
 # run a job
 npx moonset deploy --job '{
-    "input": [
-      {"glue": { "db": "foo", "table": "apple"}}
-    ],
-    "task": [
-      {"hive": {"sqlFile": "s3://foo/hive.sql"}}
-    ],
-    "output": [
-      {"glue": { "db": "foo", "table": "orange"}}
-    ]
-}' 
+    "input": [{
+        "glue": { "db": "foo", "table": "apple", "partition": {"region_id": "1", "snapshot_date": "2020-01-01"}}
+    },{
+        "glue": { "db": "foo", "table": "orange", "partition": {"region_id": "1", "snapshot_date": "2020-01-01"}}
+    }],
+    "task": [{
+        "hive": {"sqlFile": "s3://foo/hive.sql"}
+    }],
+    "output": [{
+        "glue": { "db": "foo", "table": "pineapple", "partition": {"region_id": "1", "snapshot_date": "2020-01-01"}}
+    }]
+}'
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -34,3 +34,6 @@ npx moonset deploy --job '{
 
 All resources is managed by AWS CDK so there is minimum effort for
 infrastructure setup. You can run it in a brand new account.
+
+After the EMR is setup, You can connect to both master and slave nodes via AWS
+Session Manager. No ssh key pair is needed.

--- a/README.md
+++ b/README.md
@@ -37,4 +37,6 @@ infrastructure setup. You can run it in a brand new account.
 
 The EMR is created in a VPC's private subnet, You can connect to both master
 and slave nodes via AWS Session Manager. No ssh key pair or bastion is needed.
+Follow [this guide](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-sessions-start.html)
+to start a session to connect to EMR's instances.
 

--- a/README.md
+++ b/README.md
@@ -34,3 +34,9 @@ npx moonset deploy --job '{
 
 All resources is managed by AWS CDK so there is minimum effort for
 infrastructure setup. You can run it in a brand new account.
+
+The EMR is created in a VPC's private subnet, You can connect to both master
+and slave nodes via AWS Session Manager. No ssh key pair or bastion is needed.
+Follow [this guide](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-sessions-start.html)
+to start a session to connect to EMR's instances.
+

--- a/README.md
+++ b/README.md
@@ -35,5 +35,6 @@ npx moonset deploy --job '{
 All resources is managed by AWS CDK so there is minimum effort for
 infrastructure setup. You can run it in a brand new account.
 
-After the EMR is setup, You can connect to both master and slave nodes via AWS
-Session Manager. No ssh key pair is needed.
+The EMR is created in a VPC's private subnet, You can connect to both master
+and slave nodes via AWS Session Manager. No ssh key pair or bastion is needed.
+

--- a/docs/Development.md
+++ b/docs/Development.md
@@ -27,7 +27,7 @@ npx lerna run --parallel watch
 # check the diff of this deployment and online cloudformation
 npx cdk diff --app ./build/cdk.out
 # update the dependencies in package.json
-npx npm-check-updates
+npx npm-check-updates -u
 ```
 
 The packages are publish in NPM. Here are some links:

--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.0.10"
+  "version": "0.0.11"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.0.9"
+  "version": "0.0.10"
 }

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "moonset",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "moonset",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moonset",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Moonset CLI",
   "keywords": [
     "Data Processing",
@@ -33,8 +33,8 @@
     "url": "https://github.com/FBAChinaOpenSource/Moonset/issues"
   },
   "dependencies": {
-    "@moonset/executor": "^0.0.9",
-    "@moonset/util": "^0.0.9",
+    "@moonset/executor": "^0.0.10",
+    "@moonset/util": "^0.0.10",
     "@types/yargs": "^15.0.4",
     "typescript": "^3.8.3",
     "yargs": "^15.1.0"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moonset",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Moonset CLI",
   "keywords": [
     "Data Processing",
@@ -33,8 +33,8 @@
     "url": "https://github.com/FBAChinaOpenSource/Moonset/issues"
   },
   "dependencies": {
-    "@moonset/executor": "^0.0.10",
-    "@moonset/util": "^0.0.10",
+    "@moonset/executor": "^0.0.11",
+    "@moonset/util": "^0.0.11",
     "@types/yargs": "^15.0.4",
     "typescript": "^3.8.3",
     "yargs": "^15.1.0"

--- a/packages/executor/lib/cdk/moonset-app.ts
+++ b/packages/executor/lib/cdk/moonset-app.ts
@@ -8,12 +8,16 @@ import {MetastoreSyncConstruct} from './metastore-sync';
 import * as ir from '../ir';
 // eslint-disable-next-line
 import * as vi from '../visitor';
-import {Config, ConfigConstant as CC} from '@moonset/util';
+import * as path from 'path';
+import {Config, ConfigConstant as CC, DerSe} from '@moonset/util';
 
 export class MoonsetApp {
     app: cdk.App;
 
-    constructor(props: MoonsetProps) {
+    constructor() {
+      const props = DerSe.fromFile<MoonsetProps>(
+          path.join(MC.BUILD_TMP_DIR, MC.MOONSET_CDK_PROPS));
+
       this.app = new cdk.App({outdir: MC.BUILD_TMP_DIR});
 
       // Infra Stack stores some common resources like roles for reuse purpose.
@@ -107,7 +111,7 @@ class MoonsetJobStack extends cdk.Stack {
           masterInstanceType: 'm5.xlarge',
           slaveInstanceType: 'm5.xlarge',
           ec2SubnetIds: vpc.privateSubnets.map((x) => {
-              return x.subnetId;
+            return x.subnetId;
           }),
         },
         integrationPattern: sfn.ServiceIntegrationPattern.SYNC,
@@ -200,3 +204,5 @@ class MoonsetJobStack extends cdk.Stack {
     cdk.Tag.add(emrStepFunction, MC.TAG_MOONSET_TYPE, MC.TAG_MOONSET_TYPE_SF);
   }
 }
+
+new MoonsetApp().app.synth();

--- a/packages/executor/lib/cdk/moonset-app.ts
+++ b/packages/executor/lib/cdk/moonset-app.ts
@@ -58,7 +58,7 @@ interface MoonsetJobProps extends MoonsetProps {
 class MoonsetJobStack extends cdk.Stack {
   constructor(scope: cdk.App, id: string, props: MoonsetJobProps) {
     super(scope, id, props);
-    
+
     // https://github.com/aws/aws-cdk/issues/3704
     const vpc = new ec2.Vpc(props.infraStack, 'MoonsetVPC', {
       maxAzs: 1,
@@ -67,14 +67,14 @@ class MoonsetJobStack extends cdk.Stack {
         {
           subnetType: ec2.SubnetType.ISOLATED,
           name: 'MoonsetSubnet',
-        }
+        },
       ],
       gatewayEndpoints: {
         DYNAMODB: {
           service: ec2.GatewayVpcEndpointAwsService.DYNAMODB,
-          subnets: [{ subnetType: ec2.SubnetType.ISOLATED }]
-        }
-      }
+          subnets: [{subnetType: ec2.SubnetType.ISOLATED}],
+        },
+      },
     });
 
     const ec2Role = new iam.Role(props.infraStack, MC.EMR_EC2_ROLE, {

--- a/packages/executor/lib/cdk/moonset-app.ts
+++ b/packages/executor/lib/cdk/moonset-app.ts
@@ -121,6 +121,7 @@ class MoonsetJobStack extends cdk.Stack {
           instanceCount: 3,
           masterInstanceType: 'm5.xlarge',
           slaveInstanceType: 'm5.xlarge',
+          ec2KeyName: Config.get(CC.EMR_KEY_PAIR),
           ec2SubnetId: vpc.privateSubnets[0].subnetId,
         },
         integrationPattern: sfn.ServiceIntegrationPattern.SYNC,

--- a/packages/executor/lib/cdk/moonset-app.ts
+++ b/packages/executor/lib/cdk/moonset-app.ts
@@ -72,6 +72,11 @@ class MoonsetJobStack extends cdk.Stack {
       ],
     });
 
+    const sg = new ec2.SecurityGroup(props.infraStack, 'MoonsetSG', {
+      vpc: vpc,
+    });
+    sg.addIngressRule(sg, ec2.Port.allTraffic());
+
     const ec2Role = new iam.Role(props.infraStack, MC.EMR_EC2_ROLE, {
       assumedBy: new iam.ServicePrincipal('ec2.amazonaws.com'),
     });
@@ -123,6 +128,7 @@ class MoonsetJobStack extends cdk.Stack {
           slaveInstanceType: 'm5.xlarge',
           ec2KeyName: Config.get(CC.EMR_KEY_PAIR),
           ec2SubnetId: vpc.privateSubnets[0].subnetId,
+          additionalMasterSecurityGroups: [sg.securityGroupId],
         },
         integrationPattern: sfn.ServiceIntegrationPattern.SYNC,
       }),

--- a/packages/executor/lib/cdk/moonset-app.ts
+++ b/packages/executor/lib/cdk/moonset-app.ts
@@ -9,13 +9,13 @@ import * as ir from '../ir';
 // eslint-disable-next-line
 import * as vi from '../visitor';
 import * as path from 'path';
-import {Config, ConfigConstant as CC, DerSe} from '@moonset/util';
+import {Config, ConfigConstant as CC, Serde} from '@moonset/util';
 
 export class MoonsetApp {
     app: cdk.App;
 
     constructor() {
-      const props = DerSe.fromFile<MoonsetProps>(
+      const props = Serde.fromFile<MoonsetProps>(
           path.join(MC.BUILD_TMP_DIR, MC.MOONSET_PROPS));
 
       this.app = new cdk.App();

--- a/packages/executor/lib/cdk/moonset-app.ts
+++ b/packages/executor/lib/cdk/moonset-app.ts
@@ -110,9 +110,7 @@ class MoonsetJobStack extends cdk.Stack {
           instanceCount: 3,
           masterInstanceType: 'm5.xlarge',
           slaveInstanceType: 'm5.xlarge',
-          ec2SubnetIds: vpc.privateSubnets.map((x) => {
-            return x.subnetId;
-          }),
+          ec2SubnetId: vpc.privateSubnets[0].subnetId
         },
         integrationPattern: sfn.ServiceIntegrationPattern.SYNC,
       }),

--- a/packages/executor/lib/cdk/moonset-app.ts
+++ b/packages/executor/lib/cdk/moonset-app.ts
@@ -16,9 +16,9 @@ export class MoonsetApp {
 
     constructor() {
       const props = DerSe.fromFile<MoonsetProps>(
-          path.join(MC.BUILD_TMP_DIR, MC.MOONSET_CDK_PROPS));
+          path.join(MC.BUILD_TMP_DIR, MC.MOONSET_PROPS));
 
-      this.app = new cdk.App({outdir: MC.BUILD_TMP_DIR});
+      this.app = new cdk.App();
 
       // Infra Stack stores some common resources like roles for reuse purpose.
       const infraStack = new cdk.Stack(this.app, MC.INFRA_STACK, {

--- a/packages/executor/lib/cdk/moonset-app.ts
+++ b/packages/executor/lib/cdk/moonset-app.ts
@@ -72,9 +72,6 @@ class MoonsetJobStack extends cdk.Stack {
       ],
     });
 
-    const sg = new ec2.SecurityGroup(props.infraStack, 'MoonsetSG', {vpc});
-    sg.addIngressRule(sg, ec2.Port.allTraffic());
-
     const ec2Role = new iam.Role(props.infraStack, MC.EMR_EC2_ROLE, {
       assumedBy: new iam.ServicePrincipal('ec2.amazonaws.com'),
     });

--- a/packages/executor/lib/cdk/moonset-app.ts
+++ b/packages/executor/lib/cdk/moonset-app.ts
@@ -62,13 +62,9 @@ class MoonsetJobStack extends cdk.Stack {
     const vpc = new ec2.Vpc(props.infraStack, 'MoonsetVPC', {
       subnetConfiguration: [
         {
-          subnetType: ec2.SubnetType.PUBLIC,
-          name: 'Public',
-        },
-        {
           subnetType: ec2.SubnetType.PRIVATE,
           name: 'Private',
-        },
+        }
       ],
     });
 
@@ -125,7 +121,6 @@ class MoonsetJobStack extends cdk.Stack {
           masterInstanceType: 'm5.xlarge',
           slaveInstanceType: 'm5.xlarge',
           ec2SubnetId: vpc.privateSubnets[0].subnetId,
-          additionalMasterSecurityGroups: [sg.securityGroupId],
         },
         integrationPattern: sfn.ServiceIntegrationPattern.SYNC,
       }),

--- a/packages/executor/lib/cdk/moonset-app.ts
+++ b/packages/executor/lib/cdk/moonset-app.ts
@@ -59,7 +59,18 @@ class MoonsetJobStack extends cdk.Stack {
   constructor(scope: cdk.App, id: string, props: MoonsetJobProps) {
     super(scope, id, props);
 
-    const vpc = new ec2.Vpc(props.infraStack, 'MoonsetVPC');
+    const vpc = new ec2.Vpc(props.infraStack, 'MoonsetVPC', {
+      subnetConfiguration: [
+        {
+          subnetType: ec2.SubnetType.PUBLIC,
+          name: 'Public',
+        },
+        {
+          subnetType: ec2.SubnetType.PRIVATE,
+          name: 'Private',
+        },
+      ],
+    });
 
     const ec2Role = new iam.Role(props.infraStack, MC.EMR_EC2_ROLE, {
       assumedBy: new iam.ServicePrincipal('ec2.amazonaws.com'),
@@ -110,7 +121,7 @@ class MoonsetJobStack extends cdk.Stack {
           instanceCount: 3,
           masterInstanceType: 'm5.xlarge',
           slaveInstanceType: 'm5.xlarge',
-          ec2SubnetId: vpc.privateSubnets[0].subnetId
+          ec2SubnetId: vpc.privateSubnets[0].subnetId,
         },
         integrationPattern: sfn.ServiceIntegrationPattern.SYNC,
       }),

--- a/packages/executor/lib/cdk/moonset-app.ts
+++ b/packages/executor/lib/cdk/moonset-app.ts
@@ -127,7 +127,6 @@ class MoonsetJobStack extends cdk.Stack {
           instanceCount: 3,
           masterInstanceType: 'm5.xlarge',
           slaveInstanceType: 'm5.xlarge',
-          ec2KeyName: Config.get(CC.EMR_KEY_PAIR),
           ec2SubnetId: vpc.privateSubnets[0].subnetId,
           additionalMasterSecurityGroups: [sg.securityGroupId],
         },

--- a/packages/executor/lib/cdk/moonset-app.ts
+++ b/packages/executor/lib/cdk/moonset-app.ts
@@ -74,6 +74,10 @@ class MoonsetJobStack extends cdk.Stack {
           service: ec2.GatewayVpcEndpointAwsService.DYNAMODB,
           subnets: [{subnetType: ec2.SubnetType.ISOLATED}],
         },
+        S3: {
+          service: ec2.GatewayVpcEndpointAwsService.S3,
+          subnets: [{subnetType: ec2.SubnetType.ISOLATED}],
+        },
       },
     });
 

--- a/packages/executor/lib/cdk/moonset-app.ts
+++ b/packages/executor/lib/cdk/moonset-app.ts
@@ -75,12 +75,6 @@ class MoonsetJobStack extends cdk.Stack {
     const sg = new ec2.SecurityGroup(props.infraStack, 'MoonsetSG', {vpc});
     sg.addIngressRule(sg, ec2.Port.allTraffic());
 
-    new ec2.BastionHostLinux(
-        props.infraStack, 'MoonsetBastion', {
-          vpc,
-          securityGroup: sg,
-        });
-
     const ec2Role = new iam.Role(props.infraStack, MC.EMR_EC2_ROLE, {
       assumedBy: new iam.ServicePrincipal('ec2.amazonaws.com'),
     });
@@ -88,6 +82,9 @@ class MoonsetJobStack extends cdk.Stack {
     ec2Role.addManagedPolicy(
         iam.ManagedPolicy.fromAwsManagedPolicyName(
             'service-role/AmazonElasticMapReduceforEC2Role'));
+    ec2Role.addManagedPolicy(
+        iam.ManagedPolicy.fromAwsManagedPolicyName(
+            'AmazonSSMManagedInstanceCore'));
 
     new iam.CfnInstanceProfile(props.infraStack, MC.EMR_EC2_PROFILE, {
       roles: [ec2Role.roleName],

--- a/packages/executor/lib/cdk/moonset-app.ts
+++ b/packages/executor/lib/cdk/moonset-app.ts
@@ -2,6 +2,7 @@ import * as sfn from '@aws-cdk/aws-stepfunctions';
 import * as sfnTasks from '@aws-cdk/aws-stepfunctions-tasks';
 import * as iam from '@aws-cdk/aws-iam';
 import * as cdk from '@aws-cdk/core';
+import * as ec2 from '@aws-cdk/aws-ec2';
 import {MoonsetConstants as MC} from '../constants';
 import {MetastoreSyncConstruct} from './metastore-sync';
 import * as ir from '../ir';
@@ -54,6 +55,8 @@ class MoonsetJobStack extends cdk.Stack {
   constructor(scope: cdk.App, id: string, props: MoonsetJobProps) {
     super(scope, id, props);
 
+    const vpc = new ec2.Vpc(props.infraStack, 'MoonsetVPC');
+
     const ec2Role = new iam.Role(props.infraStack, MC.EMR_EC2_ROLE, {
       assumedBy: new iam.ServicePrincipal('ec2.amazonaws.com'),
     });
@@ -103,6 +106,9 @@ class MoonsetJobStack extends cdk.Stack {
           instanceCount: 3,
           masterInstanceType: 'm5.xlarge',
           slaveInstanceType: 'm5.xlarge',
+          ec2SubnetIds: vpc.privateSubnets.map((x) => {
+              return x.subnetId;
+          }),
         },
         integrationPattern: sfn.ServiceIntegrationPattern.SYNC,
       }),

--- a/packages/executor/lib/cdk/moonset-app.ts
+++ b/packages/executor/lib/cdk/moonset-app.ts
@@ -72,10 +72,14 @@ class MoonsetJobStack extends cdk.Stack {
       ],
     });
 
-    const sg = new ec2.SecurityGroup(props.infraStack, 'MoonsetSG', {
-      vpc: vpc,
-    });
+    const sg = new ec2.SecurityGroup(props.infraStack, 'MoonsetSG', {vpc});
     sg.addIngressRule(sg, ec2.Port.allTraffic());
+
+    new ec2.BastionHostLinux(
+        props.infraStack, 'MoonsetBastion', {
+          vpc,
+          securityGroup: sg,
+        });
 
     const ec2Role = new iam.Role(props.infraStack, MC.EMR_EC2_ROLE, {
       assumedBy: new iam.ServicePrincipal('ec2.amazonaws.com'),

--- a/packages/executor/lib/cdk/moonset-app.ts
+++ b/packages/executor/lib/cdk/moonset-app.ts
@@ -202,6 +202,7 @@ class MoonsetJobStack extends cdk.Stack {
       definition: chain,
     });
     cdk.Tag.add(emrStepFunction, MC.TAG_MOONSET_TYPE, MC.TAG_MOONSET_TYPE_SF);
+    cdk.Tag.add(emrStepFunction, MC.TAG_MOONSET_ID, props.id);
   }
 }
 

--- a/packages/executor/lib/constants.ts
+++ b/packages/executor/lib/constants.ts
@@ -12,4 +12,5 @@ export const MoonsetConstants = {
   EMR_ROLE: 'MoonsetEmrRole',
   SCRIPT_RUNNER: 's3://elasticmapreduce/libs/script-runner/script-runner.jar',
   BUILD_TMP_DIR: './build/cdk.out',
+  MOONSET_CDK_PROPS: '.moonset.props'
 };

--- a/packages/executor/lib/constants.ts
+++ b/packages/executor/lib/constants.ts
@@ -11,6 +11,7 @@ export const MoonsetConstants = {
   EMR_EC2_PROFILE: 'MoonsetEmrEc2Profile',
   EMR_ROLE: 'MoonsetEmrRole',
   SCRIPT_RUNNER: 's3://elasticmapreduce/libs/script-runner/script-runner.jar',
-  BUILD_TMP_DIR: './build/cdk.out',
-  MOONSET_CDK_PROPS: '.moonset.props'
+  BUILD_TMP_DIR: './build/',
+  CDK_OUT_DIR: 'cdk.out/',
+  MOONSET_PROPS: 'moonset.props'
 };

--- a/packages/executor/lib/constants.ts
+++ b/packages/executor/lib/constants.ts
@@ -11,5 +11,7 @@ export const MoonsetConstants = {
   EMR_EC2_PROFILE: 'MoonsetEmrEc2Profile',
   EMR_ROLE: 'MoonsetEmrRole',
   SCRIPT_RUNNER: 's3://elasticmapreduce/libs/script-runner/script-runner.jar',
-  BUILD_TMP_DIR: './build/cdk.out',
+  BUILD_TMP_DIR: './build/',
+  CDK_OUT_DIR: 'cdk.out/',
+  MOONSET_PROPS: 'moonset.props'
 };

--- a/packages/executor/lib/deploy.ts
+++ b/packages/executor/lib/deploy.ts
@@ -6,7 +6,7 @@ import * as cdk from './cdk';
 import * as aws from 'aws-sdk';
 import * as TagAPI from 'aws-sdk/clients/resourcegroupstaggingapi';
 import {MoonsetConstants as MC} from './constants';
-import {Config, ConfigConstant as CC, logger, DerSe} from '@moonset/util';
+import {Config, ConfigConstant as CC, logger, Serde} from '@moonset/util';
 import * as execa from 'execa';
 import * as path from 'path';
 
@@ -40,7 +40,7 @@ export class Deployment {
 
   private async synth(context: cdk.MoonsetProps) {
 
-    DerSe.toFile(context, path.join(MC.BUILD_TMP_DIR, MC.MOONSET_PROPS));
+    Serde.toFile(context, path.join(MC.BUILD_TMP_DIR, MC.MOONSET_PROPS));
 
     const command = execa(`${require.resolve('aws-cdk/bin/cdk')}`, [
       'synth',

--- a/packages/executor/lib/deploy.ts
+++ b/packages/executor/lib/deploy.ts
@@ -20,6 +20,7 @@ export class Deployment {
   }
 
   private async deploy() {
+    // https://github.com/aws/aws-cdk/issues/3414
     const command = execa(`${require.resolve('aws-cdk/bin/cdk')}`, [
       'deploy',
       '*',

--- a/packages/executor/lib/deploy.ts
+++ b/packages/executor/lib/deploy.ts
@@ -26,7 +26,7 @@ export class Deployment {
       '*',
       '--requireApproval=never',
       `--tags="${MC.TAG_MOONSET_ID}=${context.id}"`, // tags all resources
-      `--app=${MC.BUILD_TMP_DIR}`,
+        `--app=${path.join(MC.BUILD_TMP_DIR, MC.CDK_OUT_DIR)}`,
     ], {stdio: ['ignore', 'pipe', 'pipe']});
 
     if (command.stdout) {
@@ -40,11 +40,12 @@ export class Deployment {
 
   private async synth(context: cdk.MoonsetProps) {
 
-    DerSe.toFile(context, path.join(MC.BUILD_TMP_DIR, MC.MOONSET_CDK_PROPS));
+    DerSe.toFile(context, path.join(MC.BUILD_TMP_DIR, MC.MOONSET_PROPS));
 
     const command = execa(`${require.resolve('aws-cdk/bin/cdk')}`, [
       'synth',
        `--app="node ${path.resolve(__dirname, 'cdk', 'moonset-app.js')}"`,
+       `--output=${path.join(MC.BUILD_TMP_DIR, MC.CDK_OUT_DIR)}`
     ], {stdio: ['ignore', 'pipe', 'pipe']});
 
     if (command.stdout) {

--- a/packages/executor/package-lock.json
+++ b/packages/executor/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@moonset/executor",
-	"version": "0.0.10",
+	"version": "0.0.11",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/executor/package-lock.json
+++ b/packages/executor/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@moonset/executor",
-	"version": "0.0.9",
+	"version": "0.0.10",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/executor/package.json
+++ b/packages/executor/package.json
@@ -15,7 +15,8 @@
     "test": "__tests__"
   },
   "files": [
-    "lib"
+    "lib",
+    "script"
   ],
   "repository": {
     "type": "git",

--- a/packages/executor/package.json
+++ b/packages/executor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@moonset/executor",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "The Moonset Executor",
   "keywords": [
     "AWS",
@@ -40,8 +40,8 @@
     "@aws-cdk/aws-stepfunctions": "^1.27.0",
     "@aws-cdk/aws-stepfunctions-tasks": "^1.27.0",
     "@aws-cdk/core": "^1.27.0",
-    "@moonset/model": "^0.0.9",
-    "@moonset/util": "^0.0.9",
+    "@moonset/model": "^0.0.10",
+    "@moonset/util": "^0.0.10",
     "@types/node": "^13.9.0",
     "@types/uuid": "^7.0.0",
     "aws-cdk": "^1.27.0",

--- a/packages/executor/package.json
+++ b/packages/executor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@moonset/executor",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "The Moonset Executor",
   "keywords": [
     "AWS",
@@ -41,8 +41,8 @@
     "@aws-cdk/aws-stepfunctions": "^1.27.0",
     "@aws-cdk/aws-stepfunctions-tasks": "^1.27.0",
     "@aws-cdk/core": "^1.27.0",
-    "@moonset/model": "^0.0.10",
-    "@moonset/util": "^0.0.10",
+    "@moonset/model": "^0.0.11",
+    "@moonset/util": "^0.0.11",
     "@types/node": "^13.9.0",
     "@types/uuid": "^7.0.0",
     "aws-cdk": "^1.27.0",

--- a/packages/model/package-lock.json
+++ b/packages/model/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@moonset/model",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/model/package-lock.json
+++ b/packages/model/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@moonset/model",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/model/package.json
+++ b/packages/model/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@moonset/model",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "The Moonset Model",
   "keywords": [
     "EMR",
@@ -31,7 +31,7 @@
     "url": "https://github.com/FBAChinaOpenSource/Moonset/issues"
   },
   "dependencies": {
-    "@moonset/util": "^0.0.9",
+    "@moonset/util": "^0.0.10",
     "protobufjs": "^6.8.8"
   }
 }

--- a/packages/model/package.json
+++ b/packages/model/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@moonset/model",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "The Moonset Model",
   "keywords": [
     "EMR",
@@ -31,7 +31,7 @@
     "url": "https://github.com/FBAChinaOpenSource/Moonset/issues"
   },
   "dependencies": {
-    "@moonset/util": "^0.0.10",
+    "@moonset/util": "^0.0.11",
     "protobufjs": "^6.8.8"
   }
 }

--- a/packages/util/lib/config.ts
+++ b/packages/util/lib/config.ts
@@ -1,4 +1,4 @@
-import {DerSe} from './derse';
+import {Serde} from './serde';
 import * as inquirer from 'inquirer';
 import * as os from 'os';
 import * as path from 'path';
@@ -45,7 +45,7 @@ const questions = [
 
 export class Config {
   static get(key: string) {
-    const data = DerSe.fromFile<{[k: string]: string}>(CONFIG_PATH);
+    const data = Serde.fromFile<{[k: string]: string}>(CONFIG_PATH);
     if (!data[key]) {
       throw Error(`${key} doesn't exist in ${CONFIG_PATH}.`);
     }
@@ -55,7 +55,7 @@ export class Config {
   static ask() {
     inquirer.prompt(questions).then((answers) => {
       console.log(`Write into ${CONFIG_PATH}`);
-      DerSe.toFile(answers, CONFIG_PATH);
+      Serde.toFile(answers, CONFIG_PATH);
     });
   }
 }

--- a/packages/util/lib/config.ts
+++ b/packages/util/lib/config.ts
@@ -12,6 +12,7 @@ export const ConfigConstant = {
   WORKING_ACCESS_KEY: 'WORKING_ACCESS_KEY',
   WORKING_SECRET_KEY: 'WORKING_SECRET_KEY',
   EMR_LOG: 'EMR_LOG',
+  EMR_KEY_PAIR: 'EMR_KEY_PAIR',
 };
 
 const questions = [
@@ -40,6 +41,11 @@ const questions = [
     type: 'input',
     name: ConfigConstant.EMR_LOG,
     message: 'The EMR log location in S3.',
+  },
+  {
+    type: 'input',
+    name: ConfigConstant.EMR_KEY_PAIR,
+    message: 'The EMR Key Pair.',
   },
 ];
 

--- a/packages/util/lib/config.ts
+++ b/packages/util/lib/config.ts
@@ -1,5 +1,5 @@
+import {Serde} from './serde';
 import * as inquirer from 'inquirer';
-import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 
@@ -45,7 +45,7 @@ const questions = [
 
 export class Config {
   static get(key: string) {
-    const data = JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8'));
+    const data = Serde.fromFile<{[k: string]: string}>(CONFIG_PATH);
     if (!data[key]) {
       throw Error(`${key} doesn't exist in ${CONFIG_PATH}.`);
     }
@@ -55,8 +55,7 @@ export class Config {
   static ask() {
     inquirer.prompt(questions).then((answers) => {
       console.log(`Write into ${CONFIG_PATH}`);
-      const content = JSON.stringify(answers, null, 4);
-      fs.writeFileSync(CONFIG_PATH, content, 'utf8');
+      Serde.toFile(answers, CONFIG_PATH);
     });
   }
 }

--- a/packages/util/lib/config.ts
+++ b/packages/util/lib/config.ts
@@ -12,7 +12,6 @@ export const ConfigConstant = {
   WORKING_ACCESS_KEY: 'WORKING_ACCESS_KEY',
   WORKING_SECRET_KEY: 'WORKING_SECRET_KEY',
   EMR_LOG: 'EMR_LOG',
-  EMR_KEY_PAIR: 'EMR_KEY_PAIR',
 };
 
 const questions = [
@@ -41,11 +40,6 @@ const questions = [
     type: 'input',
     name: ConfigConstant.EMR_LOG,
     message: 'The EMR log location in S3.',
-  },
-  {
-    type: 'input',
-    name: ConfigConstant.EMR_KEY_PAIR,
-    message: 'The EMR Key Pair.',
   },
 ];
 

--- a/packages/util/lib/config.ts
+++ b/packages/util/lib/config.ts
@@ -1,5 +1,5 @@
+import {DerSe} from './derse';
 import * as inquirer from 'inquirer';
-import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 
@@ -45,7 +45,7 @@ const questions = [
 
 export class Config {
   static get(key: string) {
-    const data = JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8'));
+    const data = DerSe.fromFile<{[k: string]: string}>(CONFIG_PATH);
     if (!data[key]) {
       throw Error(`${key} doesn't exist in ${CONFIG_PATH}.`);
     }
@@ -55,8 +55,7 @@ export class Config {
   static ask() {
     inquirer.prompt(questions).then((answers) => {
       console.log(`Write into ${CONFIG_PATH}`);
-      const content = JSON.stringify(answers, null, 4);
-      fs.writeFileSync(CONFIG_PATH, content, 'utf8');
+      DerSe.toFile(answers, CONFIG_PATH);
     });
   }
 }

--- a/packages/util/lib/derse.ts
+++ b/packages/util/lib/derse.ts
@@ -1,0 +1,19 @@
+import * as fs from 'fs';
+
+export class DerSe {
+  static toString<T>(obj: T): string {
+    return JSON.stringify(obj, null, 4);
+  }
+
+  static toFile<T>(obj: T, path: string) {
+    fs.writeFileSync(path, DerSe.toString(obj), 'utf8');
+  }
+
+  static fromString<T>(json: string): T {
+    return JSON.parse(json);
+  }
+
+  static fromFile<T>(path: string): T {
+    return DerSe.fromString(fs.readFileSync(path, 'utf8'));
+  }
+}

--- a/packages/util/lib/index.ts
+++ b/packages/util/lib/index.ts
@@ -1,3 +1,3 @@
 export * from './config';
-export * from './derse';
+export * from './serde';
 export * from './log';

--- a/packages/util/lib/index.ts
+++ b/packages/util/lib/index.ts
@@ -1,2 +1,3 @@
 export * from './config';
+export * from './serde';
 export * from './log';

--- a/packages/util/lib/index.ts
+++ b/packages/util/lib/index.ts
@@ -1,2 +1,3 @@
 export * from './config';
+export * from './derse';
 export * from './log';

--- a/packages/util/lib/serde.ts
+++ b/packages/util/lib/serde.ts
@@ -1,0 +1,19 @@
+import * as fs from 'fs';
+
+export class Serde {
+  static toString<T>(obj: T): string {
+    return JSON.stringify(obj, null, 4);
+  }
+
+  static toFile<T>(obj: T, path: string) {
+    fs.writeFileSync(path, Serde.toString(obj), 'utf8');
+  }
+
+  static fromString<T>(json: string): T {
+    return JSON.parse(json);
+  }
+
+  static fromFile<T>(path: string): T {
+    return Serde.fromString(fs.readFileSync(path, 'utf8'));
+  }
+}

--- a/packages/util/lib/serde.ts
+++ b/packages/util/lib/serde.ts
@@ -1,12 +1,12 @@
 import * as fs from 'fs';
 
-export class DerSe {
+export class Serde {
   static toString<T>(obj: T): string {
     return JSON.stringify(obj, null, 4);
   }
 
   static toFile<T>(obj: T, path: string) {
-    fs.writeFileSync(path, DerSe.toString(obj), 'utf8');
+    fs.writeFileSync(path, Serde.toString(obj), 'utf8');
   }
 
   static fromString<T>(json: string): T {
@@ -14,6 +14,6 @@ export class DerSe {
   }
 
   static fromFile<T>(path: string): T {
-    return DerSe.fromString(fs.readFileSync(path, 'utf8'));
+    return Serde.fromString(fs.readFileSync(path, 'utf8'));
   }
 }

--- a/packages/util/package-lock.json
+++ b/packages/util/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@moonset/util",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/util/package-lock.json
+++ b/packages/util/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@moonset/util",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@moonset/util",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Moonset Utils",
   "keywords": [
     "Data Processing",

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@moonset/util",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Moonset Utils",
   "keywords": [
     "Data Processing",


### PR DESCRIPTION
1. Invoke the synthesis from CLI instead of merely `app.synth()`. Since the CLI will inject some runtime context for synthesis phase with some information like availability zones. Such information will be missing if directly call  `app.synth()` without CLI.